### PR TITLE
Remove -lrt build flag

### DIFF
--- a/janet.go
+++ b/janet.go
@@ -3,7 +3,7 @@ package main
 /*
 #cgo CFLAGS: -fPIC -O2
 #cgo CFLAGS: -I ${SRCDIR}/deps/janet/build
-#cgo LDFLAGS: -lm -ldl -lrt -lpthread ${SRCDIR}/deps/janet/build/libjanet.a
+#cgo LDFLAGS: -lm -ldl -lpthread ${SRCDIR}/deps/janet/build/libjanet.a
 #include "janet.h"
 Janet loader_shim(int32_t argc, Janet *argv);
 const JanetReg cfuns[] = {


### PR DESCRIPTION
Currently when trying to run `go build` on OS X it fails due to the -lrt flag.
Removing it allows the build to run, not sure how this will affect other linux
OSs but preliminary research suggests it's more of a legacy thing?